### PR TITLE
add script for requesting spot instances

### DIFF
--- a/ec2/ec2_req_spot_instances.sh
+++ b/ec2/ec2_req_spot_instances.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# this script enables you to run a request for spot instances. Configure the variables according to your specific need, as well as the launch.json file to specify the instance types etc. 
+
+instanceDuration=60
+instances=2
+spotPrice="0.25"
+region="us-east-1"
+zone="us-east-1a"
+launchFile="file://launch.json"
+
+aws ec2 request-spot-instances --block-duration-minutes $instanceDuration --instance-count $instances --spot-price $spotPrice --region $region --launch-specification $launchFile

--- a/ec2/launch.json
+++ b/ec2/launch.json
@@ -1,0 +1,9 @@
+{
+    "ImageId": "ami-fed6a784",
+    "KeyName": "mykp",
+    "SecurityGroupIds": [ "sg-a9d06296" ],
+    "InstanceType": "m3.medium",
+    "Placement": {
+      "AvailabilityZone": "us-east-1a"
+    }
+  }


### PR DESCRIPTION
This is a simple script for automating the process of submitting a request for spot instances. Along with the script is a launch.json which improves readability. Users of this script can easily modify it with parameters of their specific spot instance needs. It is not very advanced, but for many aws users it is a common task, so automating it would be useful