### PR TITLE
Suggesting ECS Compose-X for AWS ECS

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ This list contains links to tools that automate or simplify the usage of AWS in 
 
 - **[Awesome ECS](https://github.com/nathanpeck/awesome-ecs)** - A curated list of awesome ECS guides, development tools, and resources.
 - **[AWS Copilot CLI](https://github.com/aws/copilot-cli)** - The AWS Copilot CLI is a tool for developers to build, release and operate production ready containerized applications on Amazon ECS and AWS Fargate.
+- **[ECS Compose-X](https://github.com/compose-x/ecs_composex)** - A python app/lib to use your existing docker-compose files, add CFN resources definitions (or via Discovery) that takes care of all the complexity (IAM, Security Groups, Secrets, Volumes etc.) and generates curated CFN templates to deploy to AWS.
 
 ### IAM
 


### PR DESCRIPTION
Suggesting ECS Compose-X in the AWS ECS toolbox.
Aimed for all levels of engineers (from new users to AWS advanced users), this allows to create CFN templates from docker-compose files, with extension fields that expand way beyond the docker+aws plugin, deals with enforcing least privileges access (although custom IAM is possible), security groups ingress, auto-tuning, side-cars, volumes, logging, advanced features, AWS AppMesh integration, etc. 
We (work) use it everyday for production and dev environment workloads, which are identical thanks to the consistent definitions of the services via a well-known (compose) definitions format and AWS CFN definitions support for resources.

Thank you for your consideration.